### PR TITLE
Fix precedence problem by replacing or with ||

### DIFF
--- a/bin/zircon_pipe
+++ b/bin/zircon_pipe
@@ -129,7 +129,7 @@ sub zconn {
         ($self->{zconn}) = @arg;
         $self->try_send; # may have been postponed due to lack of zconn
     }
-    return $self->{zconn} or
+    return $self->{zconn} ||
       die "Need zconn set now";
 }
 
@@ -261,7 +261,7 @@ sub new {
 sub zconn {
     my ($self, @arg) = @_;
     ($self->{zconn}) = @arg if @arg;
-    return $self->{zconn} or
+    return $self->{zconn} ||
       die "Need zconn set now";
 }
 

--- a/bin/zircon_pipe
+++ b/bin/zircon_pipe
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 
+use Carp;
 use IO::Handle;
 use Getopt::Long;
 use Tk;
@@ -129,8 +130,10 @@ sub zconn {
         ($self->{zconn}) = @arg;
         $self->try_send; # may have been postponed due to lack of zconn
     }
-    return $self->{zconn} ||
-      die "Need zconn set now";
+    if (!$self->{zconn}) {
+      confess "Need zconn set now";
+    }
+    return $self->{zconn};
 }
 
 
@@ -261,8 +264,11 @@ sub new {
 sub zconn {
     my ($self, @arg) = @_;
     ($self->{zconn}) = @arg if @arg;
-    return $self->{zconn} ||
-      die "Need zconn set now";
+
+    if (!$self->{zconn}) {
+      confess "Need zconn set now";
+    }
+    return $self->{zconn};
 }
 
 sub on_timeout {

--- a/t/timestamp.t
+++ b/t/timestamp.t
@@ -19,6 +19,7 @@ sub main {
     plan tests => 7;
     my $handler = do_init();
     # hold the ref to prevent garbage collection
+    print STDERR "AARRRGGG\n";
     MainLoop();
 
     return 0;
@@ -31,9 +32,11 @@ sub do_init {
     $M->clip_ids(@id);
     $M->after(10000, sub { fail("whole-test timeout"); $M->destroy });
 
+    print STDERR "GGG\n";
     my $handler = init_zircon_conn($M, @id);
     $M->state_bump(new => @id);
 
+    print STDERR "RRRGGG\n";
     return $handler;
 }
 

--- a/t/timestamp.t
+++ b/t/timestamp.t
@@ -19,7 +19,6 @@ sub main {
     plan tests => 7;
     my $handler = do_init();
     # hold the ref to prevent garbage collection
-    print STDERR "AARRRGGG\n";
     MainLoop();
 
     return 0;
@@ -32,11 +31,9 @@ sub do_init {
     $M->clip_ids(@id);
     $M->after(10000, sub { fail("whole-test timeout"); $M->destroy });
 
-    print STDERR "GGG\n";
     my $handler = init_zircon_conn($M, @id);
     $M->state_bump(new => @id);
 
-    print STDERR "RRRGGG\n";
     return $handler;
 }
 


### PR DESCRIPTION
Since Perl 5.22, it warns of possible precedence problem it cases
like : return $value or die('Sad');
return $value is tested, not $value. It can be fixed by either using
|| or by using () around the test.
The problem was already there in earlier versions of Perl but no
waring was issued.